### PR TITLE
Make installer path-independent

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,10 +141,14 @@ settings under version control.
 
 ## Installation instructions
 
-1. Clone the repository:
+> **Tip:** The installer determines its own directory at runtime, so you can
+> clone the repository anywhere (not just `~/dotfiles`) and run the script from
+> that location.
+
+1. Clone the repository (pick any directory you prefer):
    ```bash
-   git clone https://github.com/<you>/dotfiles.git ~/dotfiles
-   cd ~/dotfiles
+   git clone https://github.com/<you>/dotfiles.git /path/to/your/clone/dotfiles
+   cd /path/to/your/clone/dotfiles
    ```
 2. Make sure the installer is executable:
    ```bash

--- a/dotfiles.sh
+++ b/dotfiles.sh
@@ -6,7 +6,7 @@
 
 ########## Variables
 
-DOTFILES="$HOME/dotfiles"
+DOTFILES="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BACKUP="$DOTFILES/backup"
 OH_MY_ZSH="$HOME/.oh-my-zsh"
 PYTHON_VERSION="3.12.2"


### PR DESCRIPTION
## Summary
- derive the DOTFILES directory from the script location so backups and links work regardless of clone path
- document in the README that the installer can run from any clone location

## Testing
- bash -n dotfiles.sh

------
https://chatgpt.com/codex/tasks/task_b_68cfbc66731c8328bb837de9ea2e5fb4