### PR TITLE
Fix autosuggest strategy variable name

### DIFF
--- a/oh-my-zsh/custom/zsh-autosuggestions.zsh
+++ b/oh-my-zsh/custom/zsh-autosuggestions.zsh
@@ -1,2 +1,2 @@
 export ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE="fg=242"
-export ZSH_AUTSUGGEST_STRATEGY=(history completion)
+export ZSH_AUTOSUGGEST_STRATEGY=(history completion)


### PR DESCRIPTION
## Summary
- rename the autosuggestion strategy variable to the correct ZSH_AUTOSUGGEST_STRATEGY name so the plugin can honor the configured strategy

## Testing
- `zsh -i -c 'echo $ZSH_AUTOSUGGEST_STRATEGY'` *(fails: zsh not installed in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d76033d60083288bff0b694c83d200