### PR TITLE
Remove redundant pnpm path export from zshrc

### DIFF
--- a/shell/zshrc
+++ b/shell/zshrc
@@ -76,10 +76,3 @@ eval "$(pyenv init -)"
 eval "$(pyenv virtualenv-init -)"
 
 
-# pnpm
-export PNPM_HOME="/home/antoine/.local/share/pnpm"
-case ":$PATH:" in
-  *":$PNPM_HOME:"*) ;;
-  *) export PATH="$PNPM_HOME:$PATH" ;;
-esac
-# pnpm end


### PR DESCRIPTION
## Summary
- remove the duplicated pnpm configuration block that hard-coded the PNPM_HOME path
- retain the HOME-based PNPM_HOME export and PATH update logic in zshrc

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d7602574008328b8fe6d87fbb1ca8a