### PR TITLE
Add history substring search plugin and keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,10 @@ Regardless of the profile, the installer:
    - [powerlevel10k](https://github.com/romkatv/powerlevel10k) theme
    - [zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting)
    - [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions)
+   - [zsh-history-substring-search](https://github.com/zsh-users/zsh-history-substring-search)
    - Oh My Zsh `golang` and `z` plugins (loaded directly via zinit snippets)
+   The Up/Down arrows are bound in both Bash and Zsh to cycle through matching
+   history entries provided by the substring search plugin.
 5. **Creates symlinks to dotfiles** – backs up any existing files into
    `backup/` (timestamped copies) before linking the repository versions:
    - Shell: `~/.shell`, `~/.bashrc`, `~/.zshrc`, and `~/.p10k.zsh`.

--- a/shell/keybindings
+++ b/shell/keybindings
@@ -1,7 +1,29 @@
+# Shared keybindings for interactive shells
 
-# bindkey -e
-# Control + backspace
-bindkey '^H' backward-kill-word
-# Control + arrows
-bindkey ";5C" forward-word
-bindkey ";5D" backward-word
+if [ -n "${ZSH_VERSION:-}" ]; then
+  bindkey '^H' backward-kill-word
+  bindkey "\e[1;5C" forward-word
+  bindkey "\e[1;5D" backward-word
+
+  if (( $+functions[history-substring-search-up] )); then
+    if [[ -n ${terminfo[kcuu1]} ]]; then
+      bindkey "${terminfo[kcuu1]}" history-substring-search-up
+    else
+      bindkey '^[[A' history-substring-search-up
+    fi
+  fi
+
+  if (( $+functions[history-substring-search-down] )); then
+    if [[ -n ${terminfo[kcud1]} ]]; then
+      bindkey "${terminfo[kcud1]}" history-substring-search-down
+    else
+      bindkey '^[[B' history-substring-search-down
+    fi
+  fi
+elif [ -n "${BASH_VERSION:-}" ]; then
+  bind '"\C-H": backward-kill-word'
+  bind '"\e[1;5C": forward-word'
+  bind '"\e[1;5D": backward-word'
+  bind '"\e[A": history-search-backward'
+  bind '"\e[B": history-search-forward'
+fi

--- a/shell/zshrc
+++ b/shell/zshrc
@@ -46,6 +46,7 @@ if [[ -f "$ZINIT_MAIN" ]]; then
   zinit snippet OMZP::z
   zinit light romkatv/powerlevel10k
   zinit light zsh-users/zsh-autosuggestions
+  zinit light zsh-users/zsh-history-substring-search
   zinit light zsh-users/zsh-syntax-highlighting
 else
   echo "[WARN] zinit not available; skipping plugin setup" >&2


### PR DESCRIPTION
## Summary
- load the zsh-history-substring-search plugin alongside the existing zinit stack
- bind shared Up/Down history search shortcuts for both Zsh and Bash
- document the new history search behaviour in the README

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68e5c2f0e51083289d3a29ce3bcc1f31