### PR TITLE
Add fzf tooling with preview bindings

### DIFF
--- a/dotfiles.sh
+++ b/dotfiles.sh
@@ -290,7 +290,7 @@ install_or_update_zinit() {
 }
 
 install_ubuntu_packages() {
-    local packages=(zsh mc)
+    local packages=(zsh mc fzf fd-find ripgrep bat)
 
     if [[ "$PROFILE" == "extended" ]]; then
         packages+=(python3-pip build-essential libssl-dev zlib1g-dev libbz2-dev \

--- a/shell/interactive
+++ b/shell/interactive
@@ -10,3 +10,20 @@ if [ -t 0 ]; then
 #    if [ `tput colors` -ge 8 ]; then
 #    fi
 fi
+
+FZF_EXAMPLE_DIR="/usr/share/doc/fzf/examples"
+
+if command -v fzf >/dev/null 2>&1; then
+    if [ -n "${BASH_VERSION:-}" ] && [ -r "$FZF_EXAMPLE_DIR/key-bindings.bash" ]; then
+        # shellcheck disable=SC1090
+        . "$FZF_EXAMPLE_DIR/key-bindings.bash"
+    elif [ -n "${ZSH_VERSION:-}" ] && [ -r "$FZF_EXAMPLE_DIR/key-bindings.zsh" ]; then
+        # shellcheck disable=SC1090
+        . "$FZF_EXAMPLE_DIR/key-bindings.zsh"
+    fi
+
+    if command -v bat >/dev/null 2>&1; then
+        export FZF_CTRL_T_OPTS="--preview 'bat --style=numbers --color=always --line-range :500 {}' --preview-window=right:60%:wrap"
+        export FZF_CTRL_R_OPTS="--preview \"printf '%s\\n' {} | bat --paging=never --style=plain --language=bash -\" --preview-window=down:60%:wrap"
+    fi
+fi


### PR DESCRIPTION
## Summary
- install fzf, fd-find, ripgrep, and bat through the Ubuntu package list
- source the upstream fzf key bindings and enable bat-based previews for Ctrl-T and Ctrl-R

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e5c3025a20832888eed766b7db4a40